### PR TITLE
Remove const-ref not only const

### DIFF
--- a/P2781_constexpr_t.md
+++ b/P2781_constexpr_t.md
@@ -110,7 +110,7 @@ holds a `constexpr` value that it is given as an non-type template parameter.
 
 ```c++
 namespace std {
-  template<auto X, class T/* = remove_const_t<decltype(X)>*/>
+  template<auto X, class T/* = remove_cvref_t<decltype(X)>*/>
   struct constexpr_v
   {
     using value_type = T;
@@ -196,7 +196,7 @@ might wrap.
 
 ```c++
 namespace std {
-  template<auto X, class T/* = remove_const_t<decltype(X)>*/>
+  template<auto X, class T/* = remove_cvref_t<decltype(X)>*/>
   struct constexpr_v {
     using value_type = T;
     using type = constexpr_v;
@@ -460,7 +460,7 @@ operation during constant evaluation.
 
 ```c++
 namespace std {
-  template<auto X, class T = remove_const_t<decltype(X)>>
+  template<auto X, class T = remove_cvref_t<decltype(X)>>
     struct constexpr_v;
 
   template <class T>
@@ -683,7 +683,7 @@ Add the following to [meta.type.synop], after `false_type`:
 :::add
 
 ```c++
-template<auto X, class T = remove_const_t<decltype(X)>>
+template<auto X, class T = remove_cvref_t<decltype(X)>>
   struct constexpr_v;
 
 template <class T>


### PR DESCRIPTION
constexpr std::array<int, 4> a = {1, 2, 3, 4};
std::c_<a>[std::c_<1>]

Because of
  const int& array<int, 4>::operator[](size_t) const
we need to also remove the reference. remove_cvref_t seems like a reasonable shortcut here.